### PR TITLE
Minimize changes and fix commit logic.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/CherrypickAncestorCommitException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/CherrypickAncestorCommitException.java
@@ -25,12 +25,12 @@ package org.apache.iceberg.exceptions;
  */
 public class CherrypickAncestorCommitException extends ValidationException {
 
-  public CherrypickAncestorCommitException(Long snapshotId) {
-    super("Cannot cherrypick snapshot %s which is already an ancestor", String.valueOf(snapshotId));
+  public CherrypickAncestorCommitException(long snapshotId) {
+    super("Cannot cherrypick snapshot %s: already an ancestor", String.valueOf(snapshotId));
   }
 
-  public CherrypickAncestorCommitException(Long snapshotId, Long publishedAncestorId) {
-    super("Cannot cherrypick snapshot %s which was picked already to create an ancestor %s",
+  public CherrypickAncestorCommitException(long snapshotId, long publishedAncestorId) {
+    super("Cannot cherrypick snapshot %s: already picked to create ancestor %s",
         String.valueOf(snapshotId), String.valueOf(publishedAncestorId));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -156,12 +156,12 @@ public class BaseTable implements Table, HasTableOperations {
 
   @Override
   public Rollback rollback() {
-    return new RollbackToSnapshot(ops, this);
+    return new RollbackToSnapshot(ops);
   }
 
   @Override
   public ManageSnapshots manageSnapshots() {
-    return new SnapshotManager(ops, this);
+    return new SnapshotManager(ops);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/RollbackToSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/RollbackToSnapshot.java
@@ -21,8 +21,8 @@ package org.apache.iceberg;
 
 class RollbackToSnapshot extends SnapshotManager implements Rollback {
 
-  RollbackToSnapshot(TableOperations ops, Table table) {
-    super(ops, table);
+  RollbackToSnapshot(TableOperations ops) {
+    super(ops);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -244,6 +244,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
               updated = base.replaceCurrentSnapshot(newSnapshot);
             }
 
+            if (updated == base) {
+              // do not commit if the metadata has not changed. for example, this may happen when setting the current
+              // snapshot to an ID that is already current. note that this check uses identity.
+              return;
+            }
+
             // if the table UUID is missing, add it here. the UUID will be re-created each time this operation retries
             // to ensure that if a concurrent operation assigns the UUID, this operation will not fail.
             taskOps.commit(base, updated.withUUID());

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -34,6 +34,7 @@ public class SnapshotSummary {
   public static final String TOTAL_RECORDS_PROP = "total-records";
   public static final String DELETED_DUPLICATE_FILES = "deleted-duplicate-files";
   public static final String CHANGED_PARTITION_COUNT_PROP = "changed-partition-count";
+  public static final String STAGED_WAP_ID_PROP = "wap.id";
   public static final String PUBLISHED_WAP_ID_PROP = "published-wap-id";
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
 

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -55,29 +55,4 @@ public class SnapshotUtil {
     }
     return ancestorIds;
   }
-
-  public static boolean isCurrentAncestor(Table table, long snapshotId) {
-    List<Long> currentAncestors = SnapshotUtil.ancestorIds(table.currentSnapshot(), table::snapshot);
-    return currentAncestors.contains(snapshotId);
-  }
-
-  /**
-   * Return the latest snapshot whose timestamp is before the provided timestamp.
-   * @param table Table representing the table state on which the snapshot is being looked up
-   * @param timestampMillis lookup snapshots before this timestamp
-   * @return
-   */
-  public static Snapshot findLatestSnapshotOlderThan(Table table, long timestampMillis) {
-    long snapshotTimestamp = 0;
-    Snapshot result = null;
-    for (Long snapshotId : currentAncestors(table)) {
-      Snapshot snapshot = table.snapshot(snapshotId);
-      if (snapshot.timestampMillis() < timestampMillis &&
-          snapshot.timestampMillis() > snapshotTimestamp) {
-        result = snapshot;
-        snapshotTimestamp = snapshot.timestampMillis();
-      }
-    }
-    return result;
-  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -152,7 +153,7 @@ class Writer implements DataSourceWriter {
     if (isWapTable() && wapId != null) {
       // write-audit-publish is enabled for this table and job
       // stage the changes without changing the current snapshot
-      operation.set("wap.id", wapId);
+      operation.set(SnapshotSummary.STAGED_WAP_ID_PROP, wapId);
       operation.stageOnly();
     }
 


### PR DESCRIPTION
This updates the cherry-pick addition with a few changes. I took a closer look at the commit logic to make sure it was correct and found that I had previously made some bad recommendations. That's why I thought it would be easier for me to fix it and open a PR.

One problem was that `SnapshotManager` was keeping a `TableMetadata` instance and a `Table` instance and using those for validation. That's not a good practice because we should assume that the table metadata is changing. `Table` was passed in because I wanted to keep the `SnapshotUtil` API in terms of `Table` and not `TableMetadata` or `TableOperations`, but I think it wasn't worth it because it confuses validation logic. Instead, I've moved the ancestor methods into `SnapshotManager`. We can generalize this later if we decide to allow `SnapshotUtil` methods to accept `TableMetadata`.

Another problem was that `apply` was validating changes and then calling `super.apply` for cherry-pick operations. In `super.apply`, the table metadata is refreshed, so it could change between validating the current state and applying the changes. To fix this, I added `apply(TableMetadata)` that is called by `SnapshotProducer.apply` so that the validation is always done on the correct version.

This also catches the case where a cherry-pick is actually a fast-forward and uses that commit instead.

Last, I made some minor modifications to `TableMetadata` to minimize the overall changes.