### PR TITLE
Fix refresh logic in SnapshotProducer subclasses.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -139,7 +139,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   @Override
   public Snapshot apply() {
-    this.base = ops.refresh();
+    this.base = refresh();
     Long parentSnapshotId = base.currentSnapshot() != null ?
         base.currentSnapshot().snapshotId() : null;
 
@@ -219,6 +219,15 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         summary, SnapshotSummary.ADDED_FILES_PROP, SnapshotSummary.DELETED_FILES_PROP);
 
     return builder.build();
+  }
+
+  protected TableMetadata current() {
+    return base;
+  }
+
+  protected TableMetadata refresh() {
+    this.base = ops.refresh();
+    return base;
   }
 
   @Override


### PR DESCRIPTION
This fixes the refresh logic in `SnapshotProducer` and its subclass, `SnapshotManager`. The problem was that when snapshot manager called `ops.refresh()`, the base snapshot referenced by `SnapshotProducer` was not updated, so the actual commit always used a stale snapshot and would fail.

This happened in tests that used rollback, which refreshes metadata. The reason why it happens in tests that do not have commit conflicts is fixed by this issue: https://github.com/apache/incubator-iceberg/pull/774